### PR TITLE
updated line.here link

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ By making a real-time map of all developers you'll be able to spontaneously meet
 <h2>
 <a id="how-does-it-work" class="anchor" href="#how-does-it-work" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>How does it work</h2>
 
-<p>Apple <a href="https://twitter.com/Cocoanetics/status/211186967667412992" target="_blank">limits the number of users</a> in a location sharing group, as does <a href="http://here.line.me/en" target="_blank">line.here</a>.</p>
+<p>Apple <a href="https://twitter.com/Cocoanetics/status/211186967667412992" target="_blank">limits the number of users</a> in a location sharing group, as does <a href="https://line.me/en-US/" target="_blank">line.here</a>.</p>
 <p>This year I decided to build a basic, open source solution to share our locations. I wanted to use this opportunity to learn and use all the latest tooling, including Firebase, React Native and fastlane. You can find the source code on <a href="https://github.com/wwdc-family/app" target="_blank">GitHub</a>.</p>
 
 <h2>


### PR DESCRIPTION
It seems that line.here has been discontinued or merged with another Line app. Updated the link to the line.me homepage.
If desired, you could update the link text to something other than "line.here", as well.